### PR TITLE
16: Basic shared player state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "flow.enabled": true
+}

--- a/app/index.js
+++ b/app/index.js
@@ -1,23 +1,24 @@
-var React = require("react");
-var ReactDOM = require("react-dom");
-import App from "./components/App";
-import { Provider } from "react-redux";
-import { applyMiddleware, createStore } from "redux";
-import feastApp from "./reducers";
-import io from 'socket.io-client'
-import socketLogger from './middleware/socketLogger'
+var React = require('react');
+var ReactDOM = require('react-dom');
+import App from './components/App';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore } from 'redux';
+import feastApp from './reducers';
+import io from 'socket.io-client';
+import socketLogger from './middleware/socketLogger';
 
-const socket = io()
-socket.on('connect', function(){console.log('connected')});
+const socket = io();
+socket.on('connect', () => console.log('connected'));
+socket.on('action', action => {
+  console.log('got action', action);
+});
 socket.open();
 
-let store = createStore(feastApp,
-  applyMiddleware(socketLogger(socket))
-);
+let store = createStore(feastApp, applyMiddleware(socketLogger(socket)));
 
 ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById("app")
+  document.getElementById('app'),
 );

--- a/app/index.js
+++ b/app/index.js
@@ -9,12 +9,20 @@ import socketLogger from './middleware/socketLogger';
 
 const socket = io();
 socket.on('connect', () => console.log('connected'));
-socket.on('action', action => {
-  console.log('got action', action);
-});
-socket.open();
 
 let store = createStore(feastApp, applyMiddleware(socketLogger(socket)));
+
+socket.on('action', action => {
+  console.log('got action', action);
+  store.dispatch(
+    {
+      ...action,
+      otherPlayer: true
+    }
+  )
+});
+
+socket.open();
 
 ReactDOM.render(
   <Provider store={store}>

--- a/app/middleware/socketLogger.js
+++ b/app/middleware/socketLogger.js
@@ -1,6 +1,8 @@
 export const socketLogger = socket => store => next => action => {
-  socket.emit('action', JSON.stringify(action))
-  next(action)
-}
+  if (!action.otherPlayer) {
+    socket.emit('action', action);
+  }
+  next(action);
+};
 
-export default socketLogger
+export default socketLogger;

--- a/app/middleware/socketLogger.js
+++ b/app/middleware/socketLogger.js
@@ -2,4 +2,5 @@ export const socketLogger = socket => store => next => action => {
   socket.emit('action', JSON.stringify(action))
   next(action)
 }
+
 export default socketLogger

--- a/app/object.js
+++ b/app/object.js
@@ -1,0 +1,8 @@
+// you know pick!
+export const pick = (keys, obj) => (keys || []).reduce(
+  (acc, key) => ({
+    ...acc,
+    [key]: obj[key]
+  }),
+  {}
+)

--- a/app/reducers/gameState.test.js
+++ b/app/reducers/gameState.test.js
@@ -213,17 +213,17 @@ describe('END_TURN', () => {
       ).toMatchObject({ prestige: 3 }));
 
     describe('replenishes hand', () => {
-      test('draw five', () =>
+      test('draw a full hand', () =>
         expect(
           reduce(
             {
               ...baseState,
-              myDeck: idRange(0, 11),
+              myDeck: idRange(0, 10),
             },
             endTurn(),
           ),
         ).toMatchObject({
-          hand: idRange(6, 11).reverse(),
+          hand: idRange(6, 10).reverse(),
           myDeck: idRange(0, 6),
         }));
       test('card travels hand -> discard -> deck -> hand if necessary, maintaining order', () => {
@@ -231,8 +231,8 @@ describe('END_TURN', () => {
           {
             ...baseState,
             myDeck: idRange(0, 2),
-            discard: idRange(2, 4),
-            hand: idRange(4, 5),
+            discard: idRange(2, 3),
+            hand: idRange(3, 4),
           },
           endTurn(),
         );
@@ -246,7 +246,7 @@ describe('END_TURN', () => {
         // _with_ what was in hand
         expect(
           state.hand.slice(2, 5).sort((a, b) => (a.id < b.id ? -1 : 1)),
-        ).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }]);
+        ).toEqual([{ id: 2 }, { id: 3 }]);
       });
     });
   });

--- a/index.js
+++ b/index.js
@@ -2,13 +2,18 @@ const express = require('express');
 const app = require('express')();
 const server = require('http').createServer(app);
 const io = require('socket.io')(server);
+
 io.on('connection', socket => {
   console.log('connected');
-  socket.on('action', action => console.log('action', action));
+  socket.on('action', action => socket.broadcast.emit('action', action));
 });
 
 app.use('/', express.static('build'));
 app.use('/static', express.static('build/static'));
 app.use('/build', express.static('build'));
 
-server.listen(3000);
+const port = process.argv[2] || 3000;
+
+server.listen(port, () => {
+  console.log('listening on ' + port);
+});


### PR DESCRIPTION
This is the extremely barebones version of network play :). At least one part of it is a hack, but it was remarkably easy to get working.

* Broadcast action by any player to all others
* On receiving an action, dispatch to store with new key `otherPlayer: true`
* On reduce, if `otherPlayer`, only accept keys from the new state that are part of `commonStateKeys`, so that only a shared "view" of state is updated

Naturally a more correct state model will probably be necessary!