### PR TITLE
Show toasts of opponent actions

### DIFF
--- a/app/cardData.js
+++ b/app/cardData.js
@@ -1,0 +1,50 @@
+import Papa from 'papaparse';
+
+const parseData = ({ data }) => {
+  data.forEach(card => {
+    for (const key in card) {
+      if (card.hasOwnProperty(key)) {
+        if (!isNaN(parseInt(card[key]))) card[key] = parseInt(card[key]);
+      }
+    }
+  });
+  return data;
+};
+
+const foodCSV =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv';
+
+export const food = new Promise(ok =>
+  Papa.parse(foodCSV, {
+    download: true,
+    header: true,
+    complete: ok,
+  }),
+)
+  .then(parseData)
+  .then(d => {
+    console.log('data', d);
+    return d;
+  });
+
+const guestCSV =
+  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1152907192';
+
+export const guests = new Promise(ok =>
+  Papa.parse(guestCSV, {
+    download: true,
+    header: true,
+    complete: ok,
+  }),
+)
+  .then(parseData)
+  .then(d => {
+    console.log('data', d);
+    return d;
+  });
+
+export default Promise.all([food, guests]).then(
+  ([food, guest]) => ({
+    food, guest
+  })
+)

--- a/app/cardData.js
+++ b/app/cardData.js
@@ -20,12 +20,7 @@ export const food = new Promise(ok =>
     header: true,
     complete: ok,
   }),
-)
-  .then(parseData)
-  .then(d => {
-    console.log('data', d);
-    return d;
-  });
+).then(parseData);
 
 const guestCSV =
   'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1152907192';
@@ -36,15 +31,9 @@ export const guests = new Promise(ok =>
     header: true,
     complete: ok,
   }),
-)
-  .then(parseData)
-  .then(d => {
-    console.log('data', d);
-    return d;
-  });
+).then(parseData);
 
-export default Promise.all([food, guests]).then(
-  ([food, guest]) => ({
-    food, guest
-  })
-)
+export default Promise.all([food, guests]).then(([food, guest]) => ({
+  food,
+  guest,
+}));

--- a/app/components/FoodDeck.jsx
+++ b/app/components/FoodDeck.jsx
@@ -18,7 +18,9 @@ class FoodDeck extends Component {
   }
 
   componentDidMount() {
-    food.then(this.props.setFoodDeck);
+    food.then(cards =>
+      this.props.setFoodDeck(cards.sort(() => Math.random() - 0.5)),
+    );
   }
 
   render() {

--- a/app/components/FoodDeck.jsx
+++ b/app/components/FoodDeck.jsx
@@ -2,41 +2,23 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import FoodCard from './FoodCard';
 import { setFaceupFood, setFoodDeck } from '../actions';
-import { Position, Button } from "@blueprintjs/core";
+import { Position, Button } from '@blueprintjs/core';
 import Papa from 'papaparse';
-import Buy from "./Buy";
-import DeckOps from "./DeckOps";
-
+import Buy from './Buy';
+import DeckOps from './DeckOps';
+import { food } from '../cardData';
 import './FoodDeck.css';
 
 class FoodDeck extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      faceup: []
+      faceup: [],
     };
   }
 
   componentDidMount() {
-    const foodCSV =
-      'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv';
-    Papa.parse(foodCSV, {
-      download: true,
-      header: true,
-      complete: data => this.fillDeck(data.data),
-    });
-  }
-
-  fillDeck(data) {
-    const deck = data.sort(() => Math.random() - 0.5);
-    for (const d of deck) {
-      for (const key in d) {
-        if (d.hasOwnProperty(key)) {
-          if (!isNaN(parseInt(d[key]))) d[key] = parseInt(d[key]);
-        }
-      }
-    }
-    this.props.setFoodDeck(deck);
+    food.then(this.props.setFoodDeck);
   }
 
   render() {
@@ -47,25 +29,30 @@ class FoodDeck extends Component {
     if (remaining < 0) remaining = 0;
 
     const faceupList = faceup.map(c => (
-      <FoodCard 
-        key={c.id} 
-        dragType="buyCard" 
-        mana={this.props.gameState.mana} 
+      <FoodCard
+        key={c.id}
+        dragType="buyCard"
+        mana={this.props.gameState.mana}
         position={Position.RIGHT_TOP}
-        {...c} />
+        {...c}
+      />
     ));
 
     return (
       <div id="fooddeck">
         <div>
-          <div style={{display:"block", marginRight:"10px"}} id="image-bg">
-            <DeckOps deck={foodDeck} position={Position.RIGHT} deckname="foodDeck" dragType="buyCard"/>
+          <div style={{ display: 'block', marginRight: '10px' }} id="image-bg">
+            <DeckOps
+              deck={foodDeck}
+              position={Position.RIGHT}
+              deckname="foodDeck"
+              dragType="buyCard"
+            />
           </div>
           <div id="counter">{`${remaining} in deck`}</div>
         </div>
         <Buy dragType="buyCard" />
         {faceupList}
-        
       </div>
     );
   }

--- a/app/components/GuestDeck.jsx
+++ b/app/components/GuestDeck.jsx
@@ -1,42 +1,24 @@
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import GuestCard from "./GuestCard";
-import { setGuestDeck } from "../actions";
-import DeckOps from "./DeckOps";
-import GuestDiscard from "./GuestDiscard";
-import { Position } from "@blueprintjs/core";
-import Papa from "papaparse";
-
-import "./GuestDeck.css";
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import GuestCard from './GuestCard';
+import { setGuestDeck } from '../actions';
+import DeckOps from './DeckOps';
+import GuestDiscard from './GuestDiscard';
+import { Position } from '@blueprintjs/core';
+import Papa from 'papaparse';
+import { guests } from '../cardData';
+import './GuestDeck.css';
 
 class GuestDeck extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      faceup: []
+      faceup: [],
     };
   }
 
   componentDidMount() {
-    const guestCSV =
-      "https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1152907192";
-    Papa.parse(guestCSV, {
-      download: true,
-      header: true,
-      complete: data => this.fillDeck(data.data)
-    });
-  }
-
-  fillDeck(data) {
-    const deck = data.sort(() => Math.random() - 0.5);
-    for (const d of deck) {
-      for (const key in d) {
-        if (d.hasOwnProperty(key)) {
-          if (!isNaN(parseInt(d[key]))) d[key] = parseInt(d[key]);
-        }
-      }
-    }
-    this.props.setGuestDeck(deck);
+    guests.then(this.props.setGuestDeck);
   }
 
   render() {
@@ -47,23 +29,29 @@ class GuestDeck extends Component {
     if (remaining < 0) remaining = 0;
 
     const faceupList = faceup.map(c => (
-      <GuestCard 
-        key={c.id} 
-        dragType="guestCard" 
+      <GuestCard
+        key={c.id}
+        dragType="guestCard"
         className="faceup-item"
         position={Position.LEFT_TOP}
-        {...c} />
+        {...c}
+      />
     ));
 
     return (
       <div id="guestdeck">
         <div>
-          <div id="image-bg" style={{display:"block", marginRight:"10px"}} >
-            <DeckOps deck={guestDeck} position={Position.LEFT_TOP} deckname="guestDeck" dragType="guestCard"/>
+          <div id="image-bg" style={{ display: 'block', marginRight: '10px' }}>
+            <DeckOps
+              deck={guestDeck}
+              position={Position.LEFT_TOP}
+              deckname="guestDeck"
+              dragType="guestCard"
+            />
           </div>
-          <div id="counter">{`${remaining} in deck`}</div>        
+          <div id="counter">{`${remaining} in deck`}</div>
         </div>
-        <GuestDiscard dragType="guestCard"/>
+        <GuestDiscard dragType="guestCard" />
         {faceupList}
       </div>
     );
@@ -73,9 +61,9 @@ class GuestDeck extends Component {
 const mapStateToProps = state => ({ gameState: state.gameState });
 
 const mapDispatchToProps = dispatch => ({
-  setGuestDeck: guestDeck => dispatch(setGuestDeck(guestDeck))
+  setGuestDeck: guestDeck => dispatch(setGuestDeck(guestDeck)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {
-  withRef: true
+  withRef: true,
 })(GuestDeck);

--- a/app/components/GuestDeck.jsx
+++ b/app/components/GuestDeck.jsx
@@ -18,7 +18,9 @@ class GuestDeck extends Component {
   }
 
   componentDidMount() {
-    guests.then(this.props.setGuestDeck);
+    guests.then(cards =>
+      this.props.setGuestDeck(cards.sort(() => Math.random() - 0.5)),
+    );
   }
 
   render() {

--- a/app/index.js
+++ b/app/index.js
@@ -6,11 +6,12 @@ import { applyMiddleware, createStore } from 'redux';
 import feastApp from './reducers';
 import io from 'socket.io-client';
 import socketLogger from './middleware/socketLogger';
+import playLog from './middleware/playLog'
 
 const socket = io();
 socket.on('connect', () => console.log('connected'));
 
-let store = createStore(feastApp, applyMiddleware(socketLogger(socket)));
+let store = createStore(feastApp, applyMiddleware(socketLogger(socket), playLog));
 
 socket.on('action', action => {
   console.log('got action', action);

--- a/app/middleware/playLog.js
+++ b/app/middleware/playLog.js
@@ -1,0 +1,58 @@
+import { Toaster, Position, Intent, NumericInput } from '@blueprintjs/core';
+import cardData from '../cardData';
+
+const logToast = Toaster.create({
+  position: Position.TOP_CENTER,
+});
+
+const starter = /starter/;
+
+export const showAction = (cardData, state, action) => {
+  console.log(state);
+  switch (action.type) {
+    case 'BUY_FOOD':
+      return `Opponent bought ${
+        cardData.food.find(({ id }) => id === action.id).name
+      }!`;
+    case 'ADD_GUEST':
+      return `Opponent bought ${
+        cardData.guest.find(({ id }) => id === action.id).name
+      }!`;
+    case 'PLAY_CARD':
+      const foodName = starter.test(action.id)
+        ? 'Starter'
+        : cardData.food.find(({ id }) => id === action.id).name;
+
+      return `Opponent played ${foodName}`;
+    default:
+      return null;
+  }
+};
+
+/**
+ * show actions performed by another player.
+ * shamelessly side-effectful,
+ * but Toast APIs are all stateless :)
+ */
+export const playLog = store => next => action => {
+  if (action.otherPlayer) {
+    cardData.then(cardData => {
+      const actionMsg = showAction(
+        cardData,
+        store.getState().gameState,
+        action,
+      );
+      if (actionMsg) {
+        logToast.show({
+          message: actionMsg,
+          intent: Intent.DANGER,
+          timeout: 1000,
+        });
+      }
+    });
+  }
+
+  return next(action);
+};
+
+export default playLog;

--- a/app/middleware/playLog.js
+++ b/app/middleware/playLog.js
@@ -8,7 +8,6 @@ const logToast = Toaster.create({
 const starter = /starter/;
 
 export const showAction = (cardData, state, action) => {
-  console.log(state);
   switch (action.type) {
     case 'BUY_FOOD':
       return `Opponent bought ${


### PR DESCRIPTION
A sketch of how to provide feedback about the other player. This starts by adding red toast popups for three key actions: buying food, adding guests, playing cards. This also moves the card CSV data to a central Promise, so I can get data on cards that might not be in this player's hand or decks.