### PR TITLE
#16: Player-specific logic

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -16,8 +16,8 @@ export const shuffle = deckname => {
   return {
     type: "SHUFFLE",
     deckname: deckname
-  }
-}
+  };
+};
 
 export const trashCard = id => {
   return {
@@ -34,19 +34,19 @@ export const addGuest = (id, spot) => {
   };
 };
 
-export const discardGuest = (id) => {
+export const discardGuest = id => {
   return {
     type: "DISCARD_GUEST",
     id: id
   };
 };
 
-export const moveParty = (num) => {
+export const moveParty = num => {
   return {
     type: "MOVE_PARTY",
     num: num
-  }
-}
+  };
+};
 
 export const endTurn = () => {
   return {

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -122,3 +122,8 @@ export const setMyDeck = myDeck => {
     myDeck: myDeck
   };
 };
+
+export const pickPlayer = id => ({
+  type: "PICK_PLAYER",
+  id
+});

--- a/app/array.js
+++ b/app/array.js
@@ -2,7 +2,12 @@
 export const setAt = (idx, val, array) => [
   ...array.slice(0, idx),
   val,
-  ...array.slice(idx + 1)
+  ...array.slice(idx + 1),
 ];
 
 export const updateAt = (idx, fn, array) => setAt(idx, fn(array[idx]), array);
+
+export const pad = (toLen, withWhat, array) => [
+  ...array,
+  ...Array(withWhat).fill(toLen - array.length),
+];

--- a/app/array.js
+++ b/app/array.js
@@ -2,7 +2,7 @@
 export const setAt = (idx, val, array) => [
   ...array.slice(0, idx),
   val,
-  ...array.slice(idx+1),
-]
+  ...array.slice(idx + 1)
+];
 
-export const updateAt = (idx, fn, array) => setAt(idx, fn(array[idx]), array)
+export const updateAt = (idx, fn, array) => setAt(idx, fn(array[idx]), array);

--- a/app/array.js
+++ b/app/array.js
@@ -4,3 +4,5 @@ export const setAt = (idx, val, array) => [
   val,
   ...array.slice(idx+1),
 ]
+
+export const updateAt = (idx, fn, array) => setAt(idx, fn(array[idx]), array)

--- a/app/array.test.js
+++ b/app/array.test.js
@@ -1,9 +1,9 @@
-import { setAt } from './array';
+import { setAt } from "./array";
 
-describe('setAt', () => {
-  test('first', () => expect(setAt(0, 0, [1, 2, 3])).toEqual([0, 2, 3]));
-  test('middle', () => expect(setAt(1, 0, [1, 2, 3])).toEqual([1, 0, 3]));
-  test('last', () => expect(setAt(2, 0, [1, 2, 3])).toEqual([1, 2, 0]));
-  test('overrun is ok', () =>
+describe("setAt", () => {
+  test("first", () => expect(setAt(0, 0, [1, 2, 3])).toEqual([0, 2, 3]));
+  test("middle", () => expect(setAt(1, 0, [1, 2, 3])).toEqual([1, 0, 3]));
+  test("last", () => expect(setAt(2, 0, [1, 2, 3])).toEqual([1, 2, 0]));
+  test("overrun is ok", () =>
     expect(setAt(3, 0, [1, 2, 3])).toEqual([1, 2, 3, 0]));
 });

--- a/app/cardData.js
+++ b/app/cardData.js
@@ -1,4 +1,4 @@
-import Papa from 'papaparse';
+import Papa from "papaparse";
 
 const parseData = ({ data }) => {
   data.forEach(card => {
@@ -12,40 +12,42 @@ const parseData = ({ data }) => {
 };
 
 const foodCSV =
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv';
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv";
 
 export const food = new Promise(ok =>
   Papa.parse(foodCSV, {
     download: true,
     header: true,
-    complete: ok,
-  }),
+    complete: ok
+  })
 ).then(parseData);
 
 const guestCSV =
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1152907192';
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1152907192";
 
 export const guests = new Promise(ok =>
   Papa.parse(guestCSV, {
     download: true,
     header: true,
-    complete: ok,
-  }),
+    complete: ok
+  })
 ).then(parseData);
 
 const startingCSV =
-  'https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1960705512';
+  "https://docs.google.com/spreadsheets/d/e/2PACX-1vRFtDoZRo1q_et75CgtM3GHHXlIHiuip-GJ9wdx5iZVjI05KvhWI5fQCbxQVoBIvEy0kTASL151dJyS/pub?output=csv&gid=1960705512";
 
 export const starting = new Promise(ok =>
   Papa.parse(startingCSV, {
     download: true,
     header: true,
-    complete: ok,
-  }),
+    complete: ok
+  })
 ).then(parseData);
 
-export default Promise.all([food, guests, starting]).then(([food, guest, starting]) => ({
-  food,
-  guest,
-  starting,
-}));
+export default Promise.all([food, guests, starting]).then(
+  ([food, guest, starting]) => ({
+    food,
+    guest,
+    starting
+  })
+);

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -24,15 +24,21 @@ const prestigeToast = Toaster.create({
 });
 
 class App extends Component {
-
   componentWillUpdate(nextProps) {
-    if (this.props.gameState.prestige != nextProps.gameState.prestige) {
-      const diff = nextProps.gameState.prestige - this.props.gameState.prestige;
+    const { players, playerId } = this.props.gameState;
+    const player = players[playerId];
+    const { players: nextPlayers } = nextProps.gameState;
+    const nextPlayer = nextPlayers[playerId];
+
+    if (player.prestige != nextPlayer.prestige) {
+      const diff = nextPlayer.prestige - player.prestige;
       prestigeToast.show({
-        message: `You ${diff > 0 ? "Earned" : "Lost"} ${Math.abs(diff)} Prestige Point${Math.abs(diff) != 1 ? "s" : ""}!`,
+        message: `You ${diff > 0 ? "Earned" : "Lost"} ${Math.abs(
+          diff
+        )} Prestige Point${Math.abs(diff) != 1 ? "s" : ""}!`,
         intent: diff > 0 ? Intent.SUCCESS : Intent.DANGER,
         timeout: 1500
-      }); 
+      });
     }
   }
 
@@ -45,6 +51,9 @@ class App extends Component {
   }
 
   render() {
+    const { players, playerId } = this.props.gameState;
+    const player = players[playerId];
+
     return (
       <DragDropContextProvider backend={HTML5Backend}>
         <div id="board">
@@ -56,15 +65,25 @@ class App extends Component {
             <Party />
           </div>
           <div id="hand-row">
-            <div style={{display: "flex", width: "500px", justifyContent: "space-between", position:"absolute", top: "-40px", right: "10px", fontSize: "16px"}}>
+            <div
+              style={{
+                display: "flex",
+                width: "500px",
+                justifyContent: "space-between",
+                position: "absolute",
+                top: "-40px",
+                right: "10px",
+                fontSize: "16px"
+              }}
+            >
               <div>Mana: </div>
-              <NumericInput 
-                value={this.props.gameState.mana} 
+              <NumericInput
+                value={this.props.gameState.mana}
                 onValueChange={this.setMana.bind(this)}
               />
               <div>Prestige: </div>
-              <NumericInput 
-                value={this.props.gameState.prestige} 
+              <NumericInput
+                value={this.props.gameState.prestige}
                 onValueChange={this.setPrestige.bind(this)}
               />
             </div>

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -9,11 +9,12 @@ import Hand from "./Hand";
 import Party from "./Party";
 import Trash from "./Trash";
 import Aura from "./Aura";
+import PickPlayer from "./PickPlayer";
 import FoodDeck from "./FoodDeck";
 import GuestDeck from "./GuestDeck";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
-import { setPrestige, setMana } from "../actions";
+import { pickPlayer, setPrestige, setMana } from "../actions";
 import { Toaster, Position, Intent, NumericInput } from "@blueprintjs/core";
 
 import "./App.css";
@@ -25,6 +26,10 @@ const prestigeToast = Toaster.create({
 
 class App extends Component {
   componentWillUpdate(nextProps) {
+    if (!this.props.gameState.playerId) {
+      return;
+    }
+
     const { players, playerId } = this.props.gameState;
     const player = players[playerId];
     const { players: nextPlayers } = nextProps.gameState;
@@ -51,6 +56,10 @@ class App extends Component {
   }
 
   render() {
+    if (!this.props.gameState.playerId) {
+      return <PickPlayer pickPlayer={this.props.pickPlayer} />;
+    }
+
     const { players, playerId } = this.props.gameState;
     const player = players[playerId];
 
@@ -103,6 +112,7 @@ class App extends Component {
 const mapStateToProps = state => ({ gameState: state.gameState });
 
 const mapDispatchToProps = dispatch => ({
+  pickPlayer: id => dispatch(pickPlayer(id)),
   setMana: num => dispatch(setMana(num)),
   setPrestige: num => dispatch(setPrestige(num))
 });

--- a/app/components/Aura.jsx
+++ b/app/components/Aura.jsx
@@ -8,7 +8,6 @@ import DeckOps from "./DeckOps";
 import "./Aura.css";
 
 class Aura extends Component {
-
   handleAura(card) {
     this.props.setAura(card.id);
   }
@@ -21,8 +20,13 @@ class Aura extends Component {
     return connectDropTarget(
       <div id="aura">
         <div id="aura-bg" className={isOver ? "fade" : null}>
-          Aura<br/>
-          <DeckOps deck={aura} position={Position.TOP} deckname="aura" dragType="handCard"/>
+          Aura<br />
+          <DeckOps
+            deck={aura}
+            position={Position.TOP}
+            deckname="aura"
+            dragType="handCard"
+          />
         </div>
         <div id="counter">{`${aura.length} in aura`}</div>
       </div>

--- a/app/components/Buy.jsx
+++ b/app/components/Buy.jsx
@@ -8,7 +8,6 @@ import { Toaster, Position, Intent } from "@blueprintjs/core";
 import "./Buy.css";
 
 class Buy extends Component {
-
   handleBuy(card) {
     this.props.buyFood(card.id);
     const buyToast = Toaster.create({

--- a/app/components/Cast.jsx
+++ b/app/components/Cast.jsx
@@ -8,7 +8,6 @@ import { Toaster, Position, Intent } from "@blueprintjs/core";
 import "./Cast.css";
 
 class Cast extends Component {
-
   handleCast(card) {
     this.props.applyMana(card.food_mod);
     this.props.playCard(card.id);
@@ -24,7 +23,9 @@ class Cast extends Component {
   }
 
   render() {
-    const { mana } = this.props.gameState;
+    const { mana } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
 
     const { isOver, canDrop, connectDropTarget } = this.props;
 

--- a/app/components/DeckOps.jsx
+++ b/app/components/DeckOps.jsx
@@ -1,16 +1,20 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { applyMana, shuffle } from "../actions";
-import { Button, Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
+import {
+  Button,
+  Popover,
+  PopoverInteractionKind,
+  Position
+} from "@blueprintjs/core";
 import FoodCard from "./FoodCard.jsx";
 import GuestCard from "./GuestCard.jsx";
 
 import "./DeckOps.css";
 
 class DeckOps extends Component {
-
   shuffleDeck() {
-    const {deckname} = this.props;
+    const { deckname } = this.props;
     this.props.shuffle(deckname);
   }
 
@@ -19,28 +23,27 @@ class DeckOps extends Component {
 
     let cardList = [];
     if (["myDeck", "foodDeck", "discard", "aura"].includes(deckname)) {
-      cardList = deck.map(c => 
-        <FoodCard 
-          key={c.id} 
+      cardList = deck.map(c => (
+        <FoodCard
+          key={c.id}
           compact={true}
-          className="hand-item" 
-          dragType={dragType} 
+          className="hand-item"
+          dragType={dragType}
           position={Position.RIGHT}
-          {...c} 
+          {...c}
         />
-      );
-    }
-    else {
-      cardList = deck.map(c => 
-        <GuestCard 
-          key={c.id} 
+      ));
+    } else {
+      cardList = deck.map(c => (
+        <GuestCard
+          key={c.id}
           compact={true}
-          className="hand-item" 
-          dragType={dragType} 
+          className="hand-item"
+          dragType={dragType}
           position={Position.RIGHT}
-          {...c} 
+          {...c}
         />
-      );
+      ));
     }
 
     return (
@@ -50,11 +53,10 @@ class DeckOps extends Component {
           popoverClassName="pt-popover-content-sizing"
           position={position}
         >
-          <Button iconName="layers"></Button>
-          <div id="deckops-popover">
-            {cardList}
-          </div>
-        </Popover><br/>
+          <Button iconName="layers" />
+          <div id="deckops-popover">{cardList}</div>
+        </Popover>
+        <br />
         <Button iconName="refresh" onClick={this.shuffleDeck.bind(this)} />
       </div>
     );

--- a/app/components/Discard.jsx
+++ b/app/components/Discard.jsx
@@ -2,13 +2,12 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { DropTarget } from "react-dnd";
 import { discardFromHand } from "../actions";
-import { Position, Toaster, Intent} from "@blueprintjs/core";
+import { Position, Toaster, Intent } from "@blueprintjs/core";
 import DeckOps from "./DeckOps";
 
 import "./Discard.css";
 
 class Discard extends Component {
-
   handleDiscard(card) {
     this.props.discardFromHand(card.id);
     const discardToast = Toaster.create({
@@ -23,14 +22,21 @@ class Discard extends Component {
   }
 
   render() {
-    const { discard } = this.props.gameState;
+    const { discard } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
 
     const { isOver, canDrop, connectDropTarget } = this.props;
 
     return connectDropTarget(
       <div id="discard">
         <div id="image-bg">
-          <DeckOps deck={discard} position={Position.TOP_LEFT} deckname="discard" dragType="handCard"/>
+          <DeckOps
+            deck={discard}
+            position={Position.TOP_LEFT}
+            deckname="discard"
+            dragType="handCard"
+          />
         </div>
         <div id="counter">{`${discard.length} in discard`}</div>
       </div>

--- a/app/components/Draw.jsx
+++ b/app/components/Draw.jsx
@@ -5,7 +5,6 @@ import GuestDeck from "./GuestDeck";
 import "./Draw.css";
 
 export default class Draw extends Component {
-
   render() {
     return (
       <div id="draw">

--- a/app/components/FoodCard.jsx
+++ b/app/components/FoodCard.jsx
@@ -1,13 +1,19 @@
-import React, { Component } from 'react';
-import { DragSource } from 'react-dnd';
+import React, { Component } from "react";
+import { DragSource } from "react-dnd";
 import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
 
-import './FoodCard.css';
+import "./FoodCard.css";
 
 class FoodCard extends Component {
-
   render() {
-    const { isDragging, connectDragSource, mana, cost, position, compact} = this.props;
+    const {
+      isDragging,
+      connectDragSource,
+      mana,
+      cost,
+      position,
+      compact
+    } = this.props;
 
     const canAfford = mana >= cost;
 
@@ -20,35 +26,34 @@ class FoodCard extends Component {
           hoverOpenDelay={800}
           hoverCloseDelay={100}
         >
-          { compact 
-            ?
+          {compact ? (
             <div id="food-compact">
               <div id="name">{this.props.name}</div>
             </div>
-            :
+          ) : (
             <div id="foodcard">
               <div className="cost">
                 <span>{this.props.cost}</span>
-                <span>{canAfford ? '' : 'X'}</span>
+                <span>{canAfford ? "" : "X"}</span>
               </div>
               <div id="name">{this.props.name}</div>
-              <div id="desc" style={{ marginTop: '10px' }}>
+              <div id="desc" style={{ marginTop: "10px" }}>
                 {this.props.desc}
               </div>
             </div>
-          }
+          )}
           <div id="foodcard-big">
             <div className="cost">
               <span>{this.props.cost}</span>
-              <span>{canAfford ? '' : 'X'}</span>
+              <span>{canAfford ? "" : "X"}</span>
             </div>
             <div id="name">{this.props.name}</div>
-            <div id="desc" style={{ marginTop: '10px' }}>
+            <div id="desc" style={{ marginTop: "10px" }}>
               {this.props.desc}
             </div>
           </div>
         </Popover>
-      </div>,
+      </div>
     );
   }
 }
@@ -56,13 +61,13 @@ class FoodCard extends Component {
 const cardSource = {
   beginDrag(props) {
     return props;
-  },
+  }
 };
 
 function collect(connect, monitor) {
   return {
     connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging(),
+    isDragging: monitor.isDragging()
   };
 }
 
@@ -71,5 +76,5 @@ export default DragSource(
     return props.dragType;
   },
   cardSource,
-  collect,
+  collect
 )(FoodCard);

--- a/app/components/FoodDeck.jsx
+++ b/app/components/FoodDeck.jsx
@@ -1,30 +1,31 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import FoodCard from './FoodCard';
-import { setFaceupFood, setFoodDeck } from '../actions';
-import { Position, Button } from '@blueprintjs/core';
-import Papa from 'papaparse';
-import Buy from './Buy';
-import DeckOps from './DeckOps';
-import { food } from '../cardData';
-import './FoodDeck.css';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import FoodCard from "./FoodCard";
+import { setFaceupFood, setFoodDeck } from "../actions";
+import { Position, Button } from "@blueprintjs/core";
+import Papa from "papaparse";
+import Buy from "./Buy";
+import DeckOps from "./DeckOps";
+import { food } from "../cardData";
+import "./FoodDeck.css";
 
 class FoodDeck extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      faceup: [],
+      faceup: []
     };
   }
 
   componentDidMount() {
     food.then(cards =>
-      this.props.setFoodDeck(cards.sort(() => Math.random() - 0.5)),
+      this.props.setFoodDeck(cards.sort(() => Math.random() - 0.5))
     );
   }
 
   render() {
-    const { foodDeck } = this.props.gameState;
+    const { foodDeck, players, playerId } = this.props.gameState;
+    const mana = players[playerId];
     const FACEUP_COUNT = 4;
     const faceup = foodDeck.slice(-FACEUP_COUNT);
     let remaining = foodDeck.length - FACEUP_COUNT;
@@ -34,7 +35,7 @@ class FoodDeck extends Component {
       <FoodCard
         key={c.id}
         dragType="buyCard"
-        mana={this.props.gameState.mana}
+        mana={mana}
         position={Position.RIGHT_TOP}
         {...c}
       />
@@ -43,7 +44,7 @@ class FoodDeck extends Component {
     return (
       <div id="fooddeck">
         <div>
-          <div style={{ display: 'block', marginRight: '10px' }} id="image-bg">
+          <div style={{ display: "block", marginRight: "10px" }} id="image-bg">
             <DeckOps
               deck={foodDeck}
               position={Position.RIGHT}
@@ -63,9 +64,9 @@ class FoodDeck extends Component {
 const mapStateToProps = state => ({ gameState: state.gameState });
 
 const mapDispatchToProps = dispatch => ({
-  setFoodDeck: foodDeck => dispatch(setFoodDeck(foodDeck)),
+  setFoodDeck: foodDeck => dispatch(setFoodDeck(foodDeck))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {
-  withRef: true,
+  withRef: true
 })(FoodDeck);

--- a/app/components/GuestCard.jsx
+++ b/app/components/GuestCard.jsx
@@ -7,44 +7,51 @@ import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
 import "./GuestCard.css";
 
 class GuestCard extends Component {
-
   render() {
-    const { isDragging, connectDragSource, position, compact } = this.props;
+    const {
+      gameState,
+      isDragging,
+      connectDragSource,
+      position,
+      compact
+    } = this.props;
+    const { mana } = gameState.players[gameState.playerId];
 
     return connectDragSource(
       <div>
         <Popover
-            interactionKind={PopoverInteractionKind.HOVER}
-            popoverClassName="pt-popover-content-sizing"
-            position={position}
-            hoverOpenDelay={800}
-            hoverCloseDelay={100}
+          interactionKind={PopoverInteractionKind.HOVER}
+          popoverClassName="pt-popover-content-sizing"
+          position={position}
+          hoverOpenDelay={800}
+          hoverCloseDelay={100}
         >
-        { compact 
-          ?
-          <div id="guest-compact">
+          {compact ? (
+            <div id="guest-compact">
               <div id="name">{this.props.name}</div>
-          </div>
-          :
-          <div id="guestcard">
-            <div className="cost">
-              <span>{`${this.props.cost}c/${this.props.appetite}a/${
-                this.props.prestige
-              }p`}</span>
-              <span>{this.props.gameState.mana < this.props.cost ? "X" : ""}</span>
             </div>
-            <div id="name">{this.props.name}</div>
-            <div id="desc" style={{ marginTop: "10px" }}>
-              {this.props.desc}
+          ) : (
+            <div id="guestcard">
+              <div className="cost">
+                <span>{`${this.props.cost}c/${this.props.appetite}a/${
+                  this.props.prestige
+                }p`}</span>
+                <span>{mana < this.props.cost ? "X" : ""}</span>
+              </div>
+              <div id="name">{this.props.name}</div>
+              <div id="desc" style={{ marginTop: "10px" }}>
+                {this.props.desc}
+              </div>
             </div>
-          </div>
-        }
+          )}
           <div id="guestcard-big">
             <div className="cost">
               <span>{`${this.props.cost}c/${this.props.appetite}a/${
                 this.props.prestige
               }p`}</span>
-              <span>{this.props.gameState.mana < this.props.cost ? "X" : ""}</span>
+              <span>
+                {this.props.gameState.mana < this.props.cost ? "X" : ""}
+              </span>
             </div>
             <div id="name">{this.props.name}</div>
             <div id="desc" style={{ marginTop: "10px" }}>

--- a/app/components/GuestDeck.jsx
+++ b/app/components/GuestDeck.jsx
@@ -1,25 +1,25 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import GuestCard from './GuestCard';
-import { setGuestDeck } from '../actions';
-import DeckOps from './DeckOps';
-import GuestDiscard from './GuestDiscard';
-import { Position } from '@blueprintjs/core';
-import Papa from 'papaparse';
-import { guests } from '../cardData';
-import './GuestDeck.css';
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import GuestCard from "./GuestCard";
+import { setGuestDeck } from "../actions";
+import DeckOps from "./DeckOps";
+import GuestDiscard from "./GuestDiscard";
+import { Position } from "@blueprintjs/core";
+import Papa from "papaparse";
+import { guests } from "../cardData";
+import "./GuestDeck.css";
 
 class GuestDeck extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      faceup: [],
+      faceup: []
     };
   }
 
   componentDidMount() {
     guests.then(cards =>
-      this.props.setGuestDeck(cards.sort(() => Math.random() - 0.5)),
+      this.props.setGuestDeck(cards.sort(() => Math.random() - 0.5))
     );
   }
 
@@ -43,7 +43,7 @@ class GuestDeck extends Component {
     return (
       <div id="guestdeck">
         <div>
-          <div id="image-bg" style={{ display: 'block', marginRight: '10px' }}>
+          <div id="image-bg" style={{ display: "block", marginRight: "10px" }}>
             <DeckOps
               deck={guestDeck}
               position={Position.LEFT_TOP}
@@ -63,9 +63,9 @@ class GuestDeck extends Component {
 const mapStateToProps = state => ({ gameState: state.gameState });
 
 const mapDispatchToProps = dispatch => ({
-  setGuestDeck: guestDeck => dispatch(setGuestDeck(guestDeck)),
+  setGuestDeck: guestDeck => dispatch(setGuestDeck(guestDeck))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {
-  withRef: true,
+  withRef: true
 })(GuestDeck);

--- a/app/components/GuestDiscard.jsx
+++ b/app/components/GuestDiscard.jsx
@@ -8,7 +8,6 @@ import DeckOps from "./DeckOps";
 import "./GuestDiscard.css";
 
 class GuestDiscard extends Component {
-
   handleDiscard(card) {
     this.props.discardGuest(card.id);
     const castToast = Toaster.create({
@@ -29,10 +28,15 @@ class GuestDiscard extends Component {
 
     return connectDropTarget(
       <div>
-        <div id="image-bg" style={{display:"block"}} >
-          <DeckOps deck={guestDiscard} position={Position.LEFT_TOP} deckname="guestDiscard" dragType="guestCard"/>
+        <div id="image-bg" style={{ display: "block" }}>
+          <DeckOps
+            deck={guestDiscard}
+            position={Position.LEFT_TOP}
+            deckname="guestDiscard"
+            dragType="guestCard"
+          />
         </div>
-        <div id="counter">{`${guestDiscard.length} in discard`}</div>        
+        <div id="counter">{`${guestDiscard.length} in discard`}</div>
       </div>
     );
   }
@@ -66,9 +70,9 @@ const mapDispatchToProps = dispatch => ({
   discardGuest: id => dispatch(discardGuest(id))
 });
 
-GuestDiscard = connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(
-  GuestDiscard
-);
+GuestDiscard = connect(mapStateToProps, mapDispatchToProps, null, {
+  withRef: true
+})(GuestDiscard);
 
 export default DropTarget(
   props => {

--- a/app/components/Hand.jsx
+++ b/app/components/Hand.jsx
@@ -7,24 +7,21 @@ import FoodCard from "./FoodCard.jsx";
 import "./Hand.css";
 
 class Hand extends Component {
-
   render() {
-    const { hand } = this.props.gameState;
+    const { hand } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
     const handList = hand.map(c => (
-      <FoodCard 
-        key={c.id} 
-        className="hand-item" 
-        dragType="handCard" 
+      <FoodCard
+        key={c.id}
+        className="hand-item"
+        dragType="handCard"
         position={Position.TOP}
-        {...c} 
+        {...c}
       />
     ));
 
-    return (
-      <div id="hand-container">
-        {handList}
-      </div>
-    );
+    return <div id="hand-container">{handList}</div>;
   }
 }
 

--- a/app/components/MyDeck.jsx
+++ b/app/components/MyDeck.jsx
@@ -3,12 +3,11 @@ import { connect } from "react-redux";
 import { setMyDeck, drawCard } from "../actions";
 import DeckOps from "./DeckOps";
 import { Button, Position } from "@blueprintjs/core";
-import { starting } from '../cardData';
+import { starting } from "../cardData";
 
 import "./MyDeck.css";
 
 class MyDeck extends Component {
-
   componentDidMount() {
     const OPENING_HAND_SIZE = 4;
     starting.then(cards => {
@@ -20,20 +19,34 @@ class MyDeck extends Component {
   }
 
   onClick(e) {
-    const { myDeck } = this.props.gameState;
+    const { myDeck } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
     if (myDeck.length > 0) {
       this.props.drawCard();
     }
   }
 
   render() {
-    const { myDeck } = this.props.gameState;
+    const { myDeck } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
 
     return (
       <div id="deck">
         <div id="image-bg">
-          <DeckOps deck={myDeck} position={Position.TOP_LEFT} deckname="myDeck" dragType="handCard"/>
-          <Button onClick={this.onClick.bind(this)} style={{marginTop: "10px"}}>Draw</Button>
+          <DeckOps
+            deck={myDeck}
+            position={Position.TOP_LEFT}
+            deckname="myDeck"
+            dragType="handCard"
+          />
+          <Button
+            onClick={this.onClick.bind(this)}
+            style={{ marginTop: "10px" }}
+          >
+            Draw
+          </Button>
         </div>
         <div id="counter">{`${myDeck.length} in deck`}</div>
       </div>

--- a/app/components/MyDeck.jsx
+++ b/app/components/MyDeck.jsx
@@ -7,21 +7,29 @@ import { starting } from "../cardData";
 
 import "./MyDeck.css";
 
+const OPENING_HAND_SIZE = 4;
+
 class MyDeck extends Component {
+  getPlayer() {
+    return this.props.gameState.players[this.props.gameState.playerId];
+  }
+
   componentDidMount() {
-    const OPENING_HAND_SIZE = 4;
-    starting.then(cards => {
-      this.props.setMyDeck(cards.sort(() => Math.random() - 0.5));
-      for (let c = 0; c < OPENING_HAND_SIZE; c++) {
-        this.props.drawCard();
-      }
-    });
+    const { myDeck } = this.getPlayer();
+
+    if (!myDeck.length) {
+      starting.then(cards => {
+        this.props.setMyDeck(cards.sort(() => Math.random() - 0.5));
+        for (let c = 0; c < OPENING_HAND_SIZE; c++) {
+          this.props.drawCard();
+        }
+      });
+    }
   }
 
   onClick(e) {
-    const { myDeck } = this.props.gameState.players[
-      this.props.gameState.playerId
-    ];
+    const { myDeck } = this.getPlayer();
+
     if (myDeck.length > 0) {
       this.props.drawCard();
     }

--- a/app/components/Party.jsx
+++ b/app/components/Party.jsx
@@ -8,7 +8,6 @@ import { Toaster, Button, Position, Intent } from "@blueprintjs/core";
 import "./Party.css";
 
 class Party extends Component {
-
   endTurn() {
     this.props.endTurn();
   }
@@ -22,7 +21,9 @@ class Party extends Component {
   }
 
   render() {
-    const { party } = this.props.gameState;
+    const { party } = this.props.gameState.players[
+      this.props.gameState.playerId
+    ];
     const partyList = [];
     for (let p = 0; p < party.length; p++) {
       if (party[p].length > 0) {
@@ -31,11 +32,12 @@ class Party extends Component {
         for (let g = 0; g < guests.length; g++) {
           guestList.push(
             <div key={guests[g].id} className="stacker">
-              <GuestCard 
-                key={g.id} 
-                dragType="guestCard" 
+              <GuestCard
+                key={g.id}
+                dragType="guestCard"
                 position={Position.TOP}
-                {...guests[g]} />
+                {...guests[g]}
+              />
             </div>
           );
           guestList.push(
@@ -77,18 +79,9 @@ class Party extends Component {
     return (
       <div id="party">
         <div style={{ position: "absolute", left: "5px", top: "-35px" }}>
-          <Button 
-            iconName="cross"
-            onClick={this.endTurn.bind(this)}
-          />
-          <Button 
-            iconName="arrow-left"
-            onClick={this.moveLeft.bind(this)}
-          />
-          <Button 
-            iconName="arrow-right"
-            onClick={this.moveRight.bind(this)}
-          />
+          <Button iconName="cross" onClick={this.endTurn.bind(this)} />
+          <Button iconName="arrow-left" onClick={this.moveLeft.bind(this)} />
+          <Button iconName="arrow-right" onClick={this.moveRight.bind(this)} />
         </div>
         <div className="party-container">{tableSpots}</div>
         <div className="party-container">{partyList}</div>

--- a/app/components/Party.jsx
+++ b/app/components/Party.jsx
@@ -1,11 +1,11 @@
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import { applyMana, endTurn, moveParty } from "../actions";
-import GuestCard from "./GuestCard.jsx";
-import TableSpot from "./TableSpot.jsx";
-import { Toaster, Button, Position, Intent } from "@blueprintjs/core";
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { applyMana, endTurn, moveParty } from '../actions';
+import GuestCard from './GuestCard.jsx';
+import TableSpot from './TableSpot.jsx';
+import { Toaster, Button, Position, Intent } from '@blueprintjs/core';
 
-import "./Party.css";
+import './Party.css';
 
 class Party extends Component {
   endTurn() {
@@ -38,7 +38,7 @@ class Party extends Component {
                 position={Position.TOP}
                 {...guests[g]}
               />
-            </div>
+            </div>,
           );
           guestList.push(
             <div key={`spacehack-${g}`}>
@@ -46,23 +46,23 @@ class Party extends Component {
               <br />
               <br />
               <br />
-            </div>
+            </div>,
           );
         }
         partyList.push(
           <div
             key={`table-${p}`}
             className="hand-item"
-            style={{ width: "80px" }}
+            style={{ width: '80px' }}
           >
             {guestList}
-          </div>
+          </div>,
         );
       } else {
         partyList.push(
           <div key={`table-${p}`} className="hand-item">
             <div className="placeholder">Drag a guest above</div>
-          </div>
+          </div>,
         );
       }
     }
@@ -78,7 +78,7 @@ class Party extends Component {
 
     return (
       <div id="party">
-        <div style={{ position: "absolute", left: "5px", top: "-35px" }}>
+        <div style={{ position: 'absolute', left: '5px', top: '-35px' }}>
           <Button iconName="cross" onClick={this.endTurn.bind(this)} />
           <Button iconName="arrow-left" onClick={this.moveLeft.bind(this)} />
           <Button iconName="arrow-right" onClick={this.moveRight.bind(this)} />
@@ -95,9 +95,9 @@ const mapStateToProps = state => ({ gameState: state.gameState });
 const mapDispatchToProps = dispatch => ({
   applyMana: num => dispatch(applyMana(num)),
   endTurn: () => dispatch(endTurn()),
-  moveParty: num => dispatch(moveParty(num))
+  moveParty: num => dispatch(moveParty(num)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, null, {
-  withRef: true
+  withRef: true,
 })(Party);

--- a/app/components/PickPlayer.jsx
+++ b/app/components/PickPlayer.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import {
+  Button,
+  Popover,
+  PopoverInteractionKind,
+  Position
+} from "@blueprintjs/core";
+
+/**
+ * which player (of, currently, 2) are you?
+ */
+export const PickPlayer = ({ pickPlayer }) => (
+  <div>
+    Which player are you?
+    <Button onClick={() => pickPlayer(1)}>1</Button>
+    <Button onClick={() => pickPlayer(2)}>2</Button>
+  </div>
+);
+
+export default PickPlayer;

--- a/app/components/TableSpot.jsx
+++ b/app/components/TableSpot.jsx
@@ -7,7 +7,6 @@ import { Icon } from "@blueprintjs/core";
 import "./TableSpot.css";
 
 class TableSpot extends Component {
-
   handleInvite(guest) {
     this.props.addGuest(guest.id, this.props.spotNum);
   }
@@ -16,7 +15,11 @@ class TableSpot extends Component {
     const { spotNum } = this.props;
     const { isOver, canDrop, connectDropTarget } = this.props;
 
-    return connectDropTarget(<div id="tablespot"><Icon style={{color: "black"}} iconName="add" /> {spotNum + 1}</div>);
+    return connectDropTarget(
+      <div id="tablespot">
+        <Icon style={{ color: "black" }} iconName="add" /> {spotNum + 1}
+      </div>
+    );
   }
 }
 

--- a/app/components/Trash.jsx
+++ b/app/components/Trash.jsx
@@ -8,7 +8,6 @@ import { Toaster, Position, Intent } from "@blueprintjs/core";
 import "./Trash.css";
 
 class Trash extends Component {
-
   handleTrash(card) {
     this.props.trashCard(card.id);
     const castToast = Toaster.create({

--- a/app/index.js
+++ b/app/index.js
@@ -1,26 +1,23 @@
-var React = require("react");
-var ReactDOM = require("react-dom");
-import App from "./components/App";
-import { Provider } from "react-redux";
-import { applyMiddleware, createStore } from "redux";
-import feastApp from "./reducers";
-import io from "socket.io-client";
-import socketLogger from "./middleware/socketLogger";
-import playLog from "./middleware/playLog";
+var React = require('react');
+var ReactDOM = require('react-dom');
+import App from './components/App';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore } from 'redux';
+import feastApp from './reducers';
+import io from 'socket.io-client';
+import socketLogger from './middleware/socketLogger';
+import playLog from './middleware/playLog';
 
 const socket = io();
-socket.on("connect", () => console.log("connected"));
+socket.on('connect', () => console.log('connected'));
 
 let store = createStore(
   feastApp,
-  applyMiddleware(socketLogger(socket), playLog, store => next => action => {
-    console.log("hm", action);
-    return next(action);
-  })
+  applyMiddleware(socketLogger(socket), playLog),
 );
 
-socket.on("action", action => {
-  console.log("got action", action);
+socket.on('action', action => {
+  console.log('got action', action);
   store.dispatch(action);
 });
 
@@ -30,5 +27,5 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById("app")
+  document.getElementById('app'),
 );

--- a/app/index.js
+++ b/app/index.js
@@ -1,26 +1,27 @@
-var React = require('react');
-var ReactDOM = require('react-dom');
-import App from './components/App';
-import { Provider } from 'react-redux';
-import { applyMiddleware, createStore } from 'redux';
-import feastApp from './reducers';
-import io from 'socket.io-client';
-import socketLogger from './middleware/socketLogger';
-import playLog from './middleware/playLog'
+var React = require("react");
+var ReactDOM = require("react-dom");
+import App from "./components/App";
+import { Provider } from "react-redux";
+import { applyMiddleware, createStore } from "redux";
+import feastApp from "./reducers";
+import io from "socket.io-client";
+import socketLogger from "./middleware/socketLogger";
+import playLog from "./middleware/playLog";
 
 const socket = io();
-socket.on('connect', () => console.log('connected'));
+socket.on("connect", () => console.log("connected"));
 
-let store = createStore(feastApp, applyMiddleware(socketLogger(socket), playLog));
+let store = createStore(
+  feastApp,
+  applyMiddleware(socketLogger(socket), playLog, store => next => action => {
+    console.log("hm", action);
+    return next(action);
+  })
+);
 
-socket.on('action', action => {
-  console.log('got action', action);
-  store.dispatch(
-    {
-      ...action,
-      otherPlayer: true
-    }
-  )
+socket.on("action", action => {
+  console.log("got action", action);
+  store.dispatch(action);
 });
 
 socket.open();
@@ -29,5 +30,5 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>,
-  document.getElementById('app'),
+  document.getElementById("app")
 );

--- a/app/middleware/playLog.js
+++ b/app/middleware/playLog.js
@@ -34,7 +34,7 @@ export const showAction = (cardData, state, action) => {
  * but Toast APIs are all stateless :)
  */
 export const playLog = store => next => action => {
-  if (action.playerId !== store.getState().gameState.playerId) {
+  if (action.playerId) {
     cardData.then(cardData => {
       const actionMsg = showAction(
         cardData,

--- a/app/middleware/playLog.js
+++ b/app/middleware/playLog.js
@@ -1,25 +1,25 @@
-import { Toaster, Position, Intent, NumericInput } from '@blueprintjs/core';
-import cardData from '../cardData';
+import { Toaster, Position, Intent, NumericInput } from "@blueprintjs/core";
+import cardData from "../cardData";
 
 const logToast = Toaster.create({
-  position: Position.TOP_CENTER,
+  position: Position.TOP_CENTER
 });
 
 const starter = /starter/;
 
 export const showAction = (cardData, state, action) => {
   switch (action.type) {
-    case 'BUY_FOOD':
+    case "BUY_FOOD":
       return `Opponent bought ${
         cardData.food.find(({ id }) => id === action.id).name
       }!`;
-    case 'ADD_GUEST':
+    case "ADD_GUEST":
       return `Opponent bought ${
         cardData.guest.find(({ id }) => id === action.id).name
       }!`;
-    case 'PLAY_CARD':
+    case "PLAY_CARD":
       const foodName = starter.test(action.id)
-        ? 'Starter'
+        ? "Starter"
         : cardData.food.find(({ id }) => id === action.id).name;
 
       return `Opponent played ${foodName}`;
@@ -34,18 +34,18 @@ export const showAction = (cardData, state, action) => {
  * but Toast APIs are all stateless :)
  */
 export const playLog = store => next => action => {
-  if (action.otherPlayer) {
+  if (action.playerId !== store.getState().gameState.playerId) {
     cardData.then(cardData => {
       const actionMsg = showAction(
         cardData,
         store.getState().gameState,
-        action,
+        action
       );
       if (actionMsg) {
         logToast.show({
           message: actionMsg,
           intent: Intent.DANGER,
-          timeout: 1000,
+          timeout: 1000
         });
       }
     });

--- a/app/middleware/socketLogger.js
+++ b/app/middleware/socketLogger.js
@@ -1,7 +1,16 @@
 export const socketLogger = socket => store => next => action => {
-  if (!action.otherPlayer) {
-    socket.emit('action', action);
+  // XXX: implicitly this is us
+  if (action.playerId == null) {
+    return next({
+      ...action,
+      playerId: store.getState().gameState.playerId
+    });
   }
+
+  if (action.playerId !== store.getState().gameState.playerId) {
+    socket.emit("action", action);
+  }
+
   next(action);
 };
 

--- a/app/middleware/socketLogger.js
+++ b/app/middleware/socketLogger.js
@@ -1,14 +1,13 @@
 export const socketLogger = socket => store => next => action => {
-  // XXX: implicitly this is us
   if (action.playerId == null) {
-    return next({
-      ...action,
-      playerId: store.getState().gameState.playerId
-    });
-  }
+    const playerId = store.getState().gameState.playerId;
 
-  if (action.playerId !== store.getState().gameState.playerId) {
-    socket.emit("action", action);
+    if (playerId) {
+      socket.emit("action", {
+        ...action,
+        playerId
+      });
+    }
   }
 
   next(action);

--- a/app/object.js
+++ b/app/object.js
@@ -1,8 +1,9 @@
 // you know pick!
-export const pick = (keys, obj) => (keys || []).reduce(
-  (acc, key) => ({
-    ...acc,
-    [key]: obj[key]
-  }),
-  {}
-)
+export const pick = (keys, obj) =>
+  (keys || []).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: obj[key]
+    }),
+    {}
+  );

--- a/app/reducers/gameState.js
+++ b/app/reducers/gameState.js
@@ -1,5 +1,5 @@
-import { setAt, updateAt } from "../array";
-import { pick } from "../object";
+import { setAt, updateAt } from '../array';
+import { pick } from '../object';
 
 export const blankPlayer = {
   mana: 100,
@@ -8,7 +8,7 @@ export const blankPlayer = {
   discard: [],
   party: [[], [], [], [], [], [], []],
   partyPool: [],
-  prestige: 0
+  prestige: 0,
 };
 
 export const baseState = {
@@ -16,19 +16,19 @@ export const baseState = {
   playerId: 1,
   players: {
     1: blankPlayer,
-    2: blankPlayer
+    2: blankPlayer,
   },
   foodDeck: [],
   guestDeck: [],
   guestDiscard: [],
   trash: [],
-  aura: []
+  aura: [],
 };
 
 export const discardHand = player => ({
   ...player,
   hand: [],
-  discard: [...player.discard, ...player.hand]
+  discard: [...player.discard, ...player.hand],
 });
 
 /**
@@ -40,16 +40,16 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
   const sanitizedState = {
     ...state,
     players: Object.values(state.players).map(player => ({
-      ...["hand", "myDeck", "discard"].reduce(
+      ...['hand', 'myDeck', 'discard'].reduce(
         (player_, loc) => ({
           ...player_,
-          [loc]: player_[loc].filter(c => c.id !== cardId)
+          [loc]: player_[loc].filter(c => c.id !== cardId),
         }),
-        player
+        player,
       ),
       // party is special due to being a list of lists
-      party: player.party.map(table => table.filter(c => c.id !== cardId))
-    }))
+      party: player.party.map(table => table.filter(c => c.id !== cardId)),
+    })),
   };
 
   if (!target) {
@@ -63,9 +63,9 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
       ...sanitizedState.players,
       [playerId]: {
         ...sanitizedState.players[playerId],
-        [target]: sanitizedState.players[playerId][target].concat(cardId)
-      }
-    }
+        [target]: sanitizedState.players[playerId][target].concat(cardId),
+      },
+    },
   };
 };
 
@@ -74,7 +74,7 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
  */
 const moveCard = (state, id, target) => {
   const newState = {};
-  for (let loc of ["foodDeck", "guestDeck", "guestDiscard", "aura"]) {
+  for (let loc of ['foodDeck', 'guestDeck', 'guestDiscard', 'aura']) {
     let sourceCard = state[loc].find(c => c.id == id);
     if (sourceCard) {
       newState[loc] = state[loc].filter(c => c.id != id);
@@ -84,7 +84,7 @@ const moveCard = (state, id, target) => {
   }
   Object.entries(state.players).forEach(
     ([playerId, player]) =>
-      (state.players[playerId] = moveCardToPlayer(state, id, playerId))
+      (state.players[playerId] = moveCardToPlayer(state, id, playerId)),
   );
   return newState;
 };
@@ -98,7 +98,7 @@ const replenish = player =>
     : {
         ...player,
         myDeck: player.discard.sort(() => Math.random() - 0.5),
-        discard: []
+        discard: [],
       };
 
 export const drawCard = player => {
@@ -145,9 +145,9 @@ export const routeForPlayer = reducer => (state = baseState, action) => {
       [action.playerId]: reducePlayer(
         state,
         state.players[action.playerId],
-        action
-      )
-    }
+        action,
+      ),
+    },
   };
 };
 
@@ -162,9 +162,9 @@ export const routeForPlayer = reducer => (state = baseState, action) => {
 const reducePlayer = (state, player, action) => {
   const { party } = player;
   switch (action.type) {
-    case "APPLY_MANA":
+    case 'APPLY_MANA':
       return { ...player, mana: player.mana + action.num };
-    case "BUY_FOOD":
+    case 'BUY_FOOD':
       const card = state.foodDeck.find(c => c.id == action.id);
 
       if (card.cost > player.mana) {
@@ -175,50 +175,52 @@ const reducePlayer = (state, player, action) => {
       return {
         ...player,
         discard,
-        mana: player.mana - card.cost
+        mana: player.mana - card.cost,
       };
-    case "DRAW_CARD":
+    case 'DRAW_CARD':
       return drawCard(player);
-    case "ADD_GUEST":
+    case 'ADD_GUEST':
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
+      const oldCard = player.partyPool.find(c => c && c.id == action.id);
+      const disCard = state.guestDiscard.find(c => c && c.id == action.id);
 
       if (newCard.cost > player.mana) {
         return player;
       }
 
-      const oldCard = player.partyPool.find(c => c && c.id == action.id);
+      const foundCard = newCard || oldCard || disCard;
 
-      const newParty = oldCard
+      const newParty = foundCard
         ? updateAt(
             action.spot,
-            guests => [...guests, oldCard],
-            party.map(table => table.filter(({ id }) => id !== action.id))
+            guests => [...guests, foundCard],
+            party.map(table => table.filter(({ id }) => id !== action.id)),
           )
         : party;
 
       return {
         ...player,
         party: newParty,
-        partyPool: [...player.partyPool, newCard],
-        mana: player.mana - newCard.cost
+        partyPool: [...player.partyPool, foundCard],
+        mana: player.mana - foundCard.cost,
       };
-    case "END_TURN":
+    case 'END_TURN':
       const prestigeEarned = party.reduce(
         (acc, table) =>
           acc +
           table.reduce((tableTotal, { prestige }) => tableTotal + prestige, 0),
-        0
+        0,
       );
 
       return drawCards(
         4,
         discardHand({
           ...player,
-          prestige: Math.max(0, prestigeEarned + player.prestige)
-        })
+          prestige: Math.max(0, prestigeEarned + player.prestige),
+        }),
       );
 
-    case "MOVE_PARTY":
+    case 'MOVE_PARTY':
       const clamp = num => Math.max(0, Math.min(party.length));
       const start = clamp(0 - action.num);
       const end = clamp(party.length - action.num);
@@ -226,27 +228,27 @@ const reducePlayer = (state, player, action) => {
       return {
         ...player,
         party: movedParty,
-        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], [])
+        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], []),
       };
-    case "SET_PRESTIGE":
+    case 'SET_PRESTIGE':
       return Object.assign({}, player, { prestige: action.num });
-    case "SET_MANA":
+    case 'SET_MANA':
       return Object.assign({}, player, { mana: action.num });
-    case "SET_HAND":
+    case 'SET_HAND':
       return Object.assign({}, player, { hand: action.hand });
-    case "SET_MY_DECK":
+    case 'SET_MY_DECK':
       return Object.assign({}, player, { myDeck: action.myDeck });
-    case "SHUFFLE":
+    case 'SHUFFLE':
       const shuffleobj = {};
       shuffleobj[action.deckname] = player[action.deckname].sort(
-        () => Math.random() - 0.5
+        () => Math.random() - 0.5,
       );
       return Object.assign({}, player, shuffleobj);
-    case "DISCARD_FROM_HAND":
+    case 'DISCARD_FROM_HAND':
       return Object.assign(
         {},
         state,
-        moveCardToPlayer(state, action.id, action.playerId, "discard")
+        moveCardToPlayer(state, action.id, action.playerId, 'discard'),
       );
 
     default:
@@ -266,10 +268,10 @@ export const gameState = routeForPlayer((state = baseState, action) => {
     myDeck,
     aura,
     trash,
-    discard
+    discard,
   } = state;
   switch (action.type) {
-    case "BUY_FOOD":
+    case 'BUY_FOOD':
       card = state.foodDeck.find(c => c.id == action.id);
 
       const cost = card.cost;
@@ -281,9 +283,9 @@ export const gameState = routeForPlayer((state = baseState, action) => {
       foodDeck = state.foodDeck.filter(c => c.id != action.id);
       return {
         ...state,
-        foodDeck
+        foodDeck,
       };
-    case "ADD_GUEST":
+    case 'ADD_GUEST':
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
       if (state.players[action.playerId].mana < newCard.cost) {
         return state;
@@ -294,41 +296,41 @@ export const gameState = routeForPlayer((state = baseState, action) => {
       if (newCard) {
         guestDeck = state.guestDeck.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDeck
+          guestDeck,
         });
       } else if (disCard) {
         guestDiscard = state.guestDiscard.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDiscard
+          guestDiscard,
         });
       }
       return newState;
-    case "MOVE_PARTY":
+    case 'MOVE_PARTY':
       return {
         ...state,
         guestDiscard: state.guestDiscard.concat(
-          state.players[action.playerId].party[0]
-        )
+          state.players[action.playerId].party[0],
+        ),
       };
-    case "DISCARD_GUEST":
+    case 'DISCARD_GUEST':
       return Object.assign(
         {},
         state,
-        moveCard(state, action.id, "guestDiscard")
+        moveCard(state, action.id, 'guestDiscard'),
       );
-    case "TRASH_CARD":
-      return Object.assign({}, state, moveCard(state, action.id, "trash"));
-    case "SET_AURA":
-      return Object.assign({}, state, moveCard(state, action.id, "aura"));
-    case "PLAY_CARD":
+    case 'TRASH_CARD':
+      return Object.assign({}, state, moveCard(state, action.id, 'trash'));
+    case 'SET_AURA':
+      return Object.assign({}, state, moveCard(state, action.id, 'aura'));
+    case 'PLAY_CARD':
       return Object.assign(
         {},
         state,
-        moveCardToPlayer(state, action.id, action.playerId, "discard")
+        moveCardToPlayer(state, action.id, action.playerId, 'discard'),
       );
-    case "SET_FOOD_DECK":
+    case 'SET_FOOD_DECK':
       return Object.assign({}, state, { foodDeck: action.foodDeck });
-    case "SET_GUEST_DECK":
+    case 'SET_GUEST_DECK':
       return Object.assign({}, state, { guestDeck: action.guestDeck });
     default:
       return state;

--- a/app/reducers/gameState.js
+++ b/app/reducers/gameState.js
@@ -1,4 +1,4 @@
-import { setAt, updateAt } from '../array';
+import { pad, setAt, updateAt } from '../array';
 import { pick } from '../object';
 
 export const blankPlayer = {
@@ -216,10 +216,10 @@ const reducePlayer = (state, player, action) => {
       );
 
     case 'MOVE_PARTY':
-      const clamp = num => Math.max(0, Math.min(party.length));
+      const clamp = num => Math.max(0, Math.min(party.length, num));
       const start = clamp(0 - action.num);
       const end = clamp(party.length - action.num);
-      const movedParty = party.slice(start, end);
+      const movedParty = pad(7, [], party.slice(start, end));
       return {
         ...player,
         party: movedParty,

--- a/app/reducers/gameState.js
+++ b/app/reducers/gameState.js
@@ -1,5 +1,5 @@
-import { setAt, updateAt } from '../array';
-import { pick } from '../object';
+import { setAt, updateAt } from "../array";
+import { pick } from "../object";
 
 export const blankPlayer = {
   mana: 100,
@@ -8,27 +8,25 @@ export const blankPlayer = {
   discard: [],
   party: [[], [], [], [], [], [], []],
   partyPool: [],
-  prestige: 0,
+  prestige: 0
 };
 
 export const baseState = {
-  // TODO not this
-  playerId: 1,
   players: {
     1: blankPlayer,
-    2: blankPlayer,
+    2: blankPlayer
   },
   foodDeck: [],
   guestDeck: [],
   guestDiscard: [],
   trash: [],
-  aura: [],
+  aura: []
 };
 
 export const discardHand = player => ({
   ...player,
   hand: [],
-  discard: [...player.discard, ...player.hand],
+  discard: [...player.discard, ...player.hand]
 });
 
 /**
@@ -40,16 +38,16 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
   const sanitizedState = {
     ...state,
     players: Object.values(state.players).map(player => ({
-      ...['hand', 'myDeck', 'discard'].reduce(
+      ...["hand", "myDeck", "discard"].reduce(
         (player_, loc) => ({
           ...player_,
-          [loc]: player_[loc].filter(c => c.id !== cardId),
+          [loc]: player_[loc].filter(c => c.id !== cardId)
         }),
-        player,
+        player
       ),
       // party is special due to being a list of lists
-      party: player.party.map(table => table.filter(c => c.id !== cardId)),
-    })),
+      party: player.party.map(table => table.filter(c => c.id !== cardId))
+    }))
   };
 
   if (!target) {
@@ -63,9 +61,9 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
       ...sanitizedState.players,
       [playerId]: {
         ...sanitizedState.players[playerId],
-        [target]: sanitizedState.players[playerId][target].concat(cardId),
-      },
-    },
+        [target]: sanitizedState.players[playerId][target].concat(cardId)
+      }
+    }
   };
 };
 
@@ -74,7 +72,7 @@ const moveCardToPlayer = (state, cardId, playerId, target) => {
  */
 const moveCard = (state, id, target) => {
   const newState = {};
-  for (let loc of ['foodDeck', 'guestDeck', 'guestDiscard', 'aura']) {
+  for (let loc of ["foodDeck", "guestDeck", "guestDiscard", "aura"]) {
     let sourceCard = state[loc].find(c => c.id == id);
     if (sourceCard) {
       newState[loc] = state[loc].filter(c => c.id != id);
@@ -84,7 +82,7 @@ const moveCard = (state, id, target) => {
   }
   Object.entries(state.players).forEach(
     ([playerId, player]) =>
-      (state.players[playerId] = moveCardToPlayer(state, id, playerId)),
+      (state.players[playerId] = moveCardToPlayer(state, id, playerId))
   );
   return newState;
 };
@@ -98,7 +96,7 @@ const replenish = player =>
     : {
         ...player,
         myDeck: player.discard.sort(() => Math.random() - 0.5),
-        discard: [],
+        discard: []
       };
 
 export const drawCard = player => {
@@ -133,21 +131,21 @@ export const drawCards = (howMany, player) => {
  * discard anything that isn't shared.
  * so, eg, ignore .hand if the other player drew a card.
  */
-export const routeForPlayer = reducer => (state = baseState, action) => {
-  if (action.playerId == null) {
-    return reducer(state, action);
-  }
+export const routeForPlayer = reducer => (state = baseState, baseAction) => {
+  const playerId = baseAction.playerId || state.playerId;
+  const action = {
+    ...baseAction,
+    playerId
+  };
 
   return {
     ...reducer(state, action),
-    players: {
-      ...state.players,
-      [action.playerId]: reducePlayer(
-        state,
-        state.players[action.playerId],
-        action,
-      ),
-    },
+    players: playerId
+      ? {
+          ...state.players,
+          [playerId]: reducePlayer(state, state.players[playerId], action)
+        }
+      : state.players
   };
 };
 
@@ -162,9 +160,9 @@ export const routeForPlayer = reducer => (state = baseState, action) => {
 const reducePlayer = (state, player, action) => {
   const { party } = player;
   switch (action.type) {
-    case 'APPLY_MANA':
+    case "APPLY_MANA":
       return { ...player, mana: player.mana + action.num };
-    case 'BUY_FOOD':
+    case "BUY_FOOD":
       const card = state.foodDeck.find(c => c.id == action.id);
 
       if (card.cost > player.mana) {
@@ -175,11 +173,11 @@ const reducePlayer = (state, player, action) => {
       return {
         ...player,
         discard,
-        mana: player.mana - card.cost,
+        mana: player.mana - card.cost
       };
-    case 'DRAW_CARD':
+    case "DRAW_CARD":
       return drawCard(player);
-    case 'ADD_GUEST':
+    case "ADD_GUEST":
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
       const oldCard = player.partyPool.find(c => c && c.id == action.id);
       const disCard = state.guestDiscard.find(c => c && c.id == action.id);
@@ -194,7 +192,7 @@ const reducePlayer = (state, player, action) => {
         ? updateAt(
             action.spot,
             guests => [...guests, foundCard],
-            party.map(table => table.filter(({ id }) => id !== action.id)),
+            party.map(table => table.filter(({ id }) => id !== action.id))
           )
         : party;
 
@@ -202,25 +200,25 @@ const reducePlayer = (state, player, action) => {
         ...player,
         party: newParty,
         partyPool: [...player.partyPool, foundCard],
-        mana: player.mana - foundCard.cost,
+        mana: player.mana - foundCard.cost
       };
-    case 'END_TURN':
+    case "END_TURN":
       const prestigeEarned = party.reduce(
         (acc, table) =>
           acc +
           table.reduce((tableTotal, { prestige }) => tableTotal + prestige, 0),
-        0,
+        0
       );
 
       return drawCards(
         4,
         discardHand({
           ...player,
-          prestige: Math.max(0, prestigeEarned + player.prestige),
-        }),
+          prestige: Math.max(0, prestigeEarned + player.prestige)
+        })
       );
 
-    case 'MOVE_PARTY':
+    case "MOVE_PARTY":
       const clamp = num => Math.max(0, Math.min(party.length));
       const start = clamp(0 - action.num);
       const end = clamp(party.length - action.num);
@@ -228,27 +226,27 @@ const reducePlayer = (state, player, action) => {
       return {
         ...player,
         party: movedParty,
-        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], []),
+        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], [])
       };
-    case 'SET_PRESTIGE':
+    case "SET_PRESTIGE":
       return Object.assign({}, player, { prestige: action.num });
-    case 'SET_MANA':
+    case "SET_MANA":
       return Object.assign({}, player, { mana: action.num });
-    case 'SET_HAND':
+    case "SET_HAND":
       return Object.assign({}, player, { hand: action.hand });
-    case 'SET_MY_DECK':
+    case "SET_MY_DECK":
       return Object.assign({}, player, { myDeck: action.myDeck });
-    case 'SHUFFLE':
+    case "SHUFFLE":
       const shuffleobj = {};
       shuffleobj[action.deckname] = player[action.deckname].sort(
-        () => Math.random() - 0.5,
+        () => Math.random() - 0.5
       );
       return Object.assign({}, player, shuffleobj);
-    case 'DISCARD_FROM_HAND':
+    case "DISCARD_FROM_HAND":
       return Object.assign(
         {},
         state,
-        moveCardToPlayer(state, action.id, action.playerId, 'discard'),
+        moveCardToPlayer(state, action.id, action.playerId, "discard")
       );
 
     default:
@@ -268,10 +266,15 @@ export const gameState = routeForPlayer((state = baseState, action) => {
     myDeck,
     aura,
     trash,
-    discard,
+    discard
   } = state;
   switch (action.type) {
-    case 'BUY_FOOD':
+    case "PICK_PLAYER":
+      return {
+        ...state,
+        playerId: action.id
+      };
+    case "BUY_FOOD":
       card = state.foodDeck.find(c => c.id == action.id);
 
       const cost = card.cost;
@@ -283,9 +286,9 @@ export const gameState = routeForPlayer((state = baseState, action) => {
       foodDeck = state.foodDeck.filter(c => c.id != action.id);
       return {
         ...state,
-        foodDeck,
+        foodDeck
       };
-    case 'ADD_GUEST':
+    case "ADD_GUEST":
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
       if (state.players[action.playerId].mana < newCard.cost) {
         return state;
@@ -296,41 +299,41 @@ export const gameState = routeForPlayer((state = baseState, action) => {
       if (newCard) {
         guestDeck = state.guestDeck.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDeck,
+          guestDeck
         });
       } else if (disCard) {
         guestDiscard = state.guestDiscard.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDiscard,
+          guestDiscard
         });
       }
       return newState;
-    case 'MOVE_PARTY':
+    case "MOVE_PARTY":
       return {
         ...state,
         guestDiscard: state.guestDiscard.concat(
-          state.players[action.playerId].party[0],
-        ),
+          state.players[action.playerId].party[0]
+        )
       };
-    case 'DISCARD_GUEST':
+    case "DISCARD_GUEST":
       return Object.assign(
         {},
         state,
-        moveCard(state, action.id, 'guestDiscard'),
+        moveCard(state, action.id, "guestDiscard")
       );
-    case 'TRASH_CARD':
-      return Object.assign({}, state, moveCard(state, action.id, 'trash'));
-    case 'SET_AURA':
-      return Object.assign({}, state, moveCard(state, action.id, 'aura'));
-    case 'PLAY_CARD':
+    case "TRASH_CARD":
+      return Object.assign({}, state, moveCard(state, action.id, "trash"));
+    case "SET_AURA":
+      return Object.assign({}, state, moveCard(state, action.id, "aura"));
+    case "PLAY_CARD":
       return Object.assign(
         {},
         state,
-        moveCardToPlayer(state, action.id, action.playerId, 'discard'),
+        moveCardToPlayer(state, action.id, action.playerId, "discard")
       );
-    case 'SET_FOOD_DECK':
+    case "SET_FOOD_DECK":
       return Object.assign({}, state, { foodDeck: action.foodDeck });
-    case 'SET_GUEST_DECK':
+    case "SET_GUEST_DECK":
       return Object.assign({}, state, { guestDeck: action.guestDeck });
     default:
       return state;

--- a/app/reducers/gameState.js
+++ b/app/reducers/gameState.js
@@ -1,61 +1,93 @@
-import { setAt, updateAt } from '../array';
-import { pick } from '../object';
+import { setAt, updateAt } from "../array";
+import { pick } from "../object";
 
 export const blankPlayer = {
   mana: 100,
   hand: [],
-  deck: [],
+  myDeck: [],
   discard: [],
   party: [[], [], [], [], [], [], []],
   partyPool: [],
-  prestige: 0,
+  prestige: 0
 };
 
 export const baseState = {
+  // TODO not this
+  playerId: 1,
+  players: {
+    1: blankPlayer,
+    2: blankPlayer
+  },
   foodDeck: [],
   guestDeck: [],
   guestDiscard: [],
   trash: [],
-  aura: [],
-  players: {},
+  aura: []
 };
 
 export const discardHand = player => ({
   ...player,
   hand: [],
-  discard: [...player.discard, ...player.hand],
+  discard: [...player.discard, ...player.hand]
 });
 
 /**
- * move card from anywhere on the board to a target pile
+ * move card from anywhere on the board to a target player's pile.
+ * XXX: for now, valid target piles are 'hand', 'myDeck', 'discard',
+ * but not 'party', which requires more info about targeting.
+ */
+const moveCardToPlayer = (state, cardId, playerId, target) => {
+  const sanitizedState = {
+    ...state,
+    players: Object.values(state.players).map(player => ({
+      ...["hand", "myDeck", "discard"].reduce(
+        (player_, loc) => ({
+          ...player_,
+          [loc]: player_[loc].filter(c => c.id !== cardId)
+        }),
+        player
+      ),
+      // party is special due to being a list of lists
+      party: player.party.map(table => table.filter(c => c.id !== cardId))
+    }))
+  };
+
+  if (!target) {
+    return sanitizedState;
+  }
+
+  // AKA, from Ramda, r.over(r.lensPath['players', playerId, target]), r.append(cardId), sanitizedState)
+  return {
+    ...sanitizedState,
+    players: {
+      ...sanitizedState.players,
+      [playerId]: {
+        ...sanitizedState.players[playerId],
+        [target]: sanitizedState.players[playerId][target].concat(cardId)
+      }
+    }
+  };
+};
+
+/**
+ * move card from anywhere on the board to a shared target pile
  */
 const moveCard = (state, id, target) => {
   const newState = {};
-  for (let loc of [
-    'hand',
-    'myDeck',
-    'discard',
-    'foodDeck',
-    'guestDeck',
-    'guestDiscard',
-    'aura',
-    'partyPool',
-  ]) {
+  for (let loc of ["foodDeck", "guestDeck", "guestDiscard", "aura"]) {
     let sourceCard = state[loc].find(c => c.id == id);
     if (sourceCard) {
       newState[loc] = state[loc].filter(c => c.id != id);
-      if (loc == 'partyPool') {
-        newState.party = [];
-        for (let i = 0; i < 7; i++) {
-          newState.party[i] = state.party[i].filter(c => c.id != id);
-        }
-      }
       if (!state[target].find(c => c.id == id))
         newState[target] = state[target].concat(sourceCard);
     }
   }
+  Object.entries(state.players).forEach(
+    ([playerId, player]) =>
+      (state.players[playerId] = moveCardToPlayer(state, id, playerId))
+  );
   return newState;
-}
+};
 
 /**
  * move discard to deck if deck is empty
@@ -66,7 +98,7 @@ const replenish = player =>
     : {
         ...player,
         myDeck: player.discard.sort(() => Math.random() - 0.5),
-        discard: [],
+        discard: []
       };
 
 export const drawCard = player => {
@@ -97,97 +129,96 @@ export const drawCards = (howMany, player) => {
 };
 
 /**
- * elements of state shared by both players
- */
-const commonStateKeys = [
-  'foodDeck',
-  'guestDeck',
-  'guestDiscard',
-  'trash',
-  'aura',
-];
-
-/**
- * defining both self- and other- state keys
- * so that omitting a key from this logic will be more
- * obvious. Safer refactoring absent a type system.
- */
-const playerStateKeys = [
-  'mana',
-  'hand',
-  'party',
-  'partyPool',
-  'myDeck',
-  'discard',
-  'prestige',
-];
-
-/**
  * if incoming action isn't me,
  * discard anything that isn't shared.
  * so, eg, ignore .hand if the other player drew a card.
  */
-export const routeForOtherPlayer = reducer => (state = baseState, action) => {
-  const newState = reducer(state, action);
+export const routeForPlayer = reducer => (state = baseState, action) => {
+  if (action.playerId == null) {
+    return reducer(state, action);
+  }
 
-  const selfView = action.otherPlayer
-    ? {
-        ...pick(playerStateKeys, state),
-        ...pick(commonStateKeys, newState),
-      }
-    : newState;
-
-  return selfView;
+  return {
+    ...reducer(state, action),
+    players: {
+      ...state.players,
+      [action.playerId]: reducePlayer(
+        state,
+        state.players[action.playerId],
+        action
+      )
+    }
+  };
 };
 
+/**
+ * update a player state for an action.
+ * operates in parallel with larger state,
+ * so for instance, doesn't know/care whether central food deck was updated.
+ * may be rickety; was mostly trying to clear player-specific logic away.
+ * perhaps unwise and better restructured as functions called
+ * by the reducer.
+ */
 const reducePlayer = (state, player, action) => {
   const { party } = player;
   switch (action.type) {
-    case 'APPLY_MANA':
-      return { mana: player.mana + action.num };
-    case 'BUY_FOOD':
-      discard = player.discard.concat(card);
+    case "APPLY_MANA":
+      return { ...player, mana: player.mana + action.num };
+    case "BUY_FOOD":
+      const card = state.foodDeck.find(c => c.id == action.id);
+
+      if (card.cost > player.mana) {
+        return player;
+      }
+
+      const discard = player.discard.concat(card);
       return {
         ...player,
         discard,
-        mana: state.mana - cost,
+        mana: player.mana - card.cost
       };
-
-    case 'ADD_GUEST':
+    case "DRAW_CARD":
+      return drawCard(player);
+    case "ADD_GUEST":
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
+
+      if (newCard.cost > player.mana) {
+        return player;
+      }
+
       const oldCard = player.partyPool.find(c => c && c.id == action.id);
 
       const newParty = oldCard
         ? updateAt(
             action.spot,
             guests => [...guests, oldCard],
-            party.map(table => table.filter(({ id }) => id !== action.id)),
+            party.map(table => table.filter(({ id }) => id !== action.id))
           )
         : party;
 
       return {
         ...player,
         party: newParty,
-        partyPool: [...state.partyPool, newCard],
-        mana: state.mana - newCard.cost,
+        partyPool: [...player.partyPool, newCard],
+        mana: player.mana - newCard.cost
       };
-    case 'END_TURN':
+    case "END_TURN":
       const prestigeEarned = party.reduce(
         (acc, table) =>
           acc +
           table.reduce((tableTotal, { prestige }) => tableTotal + prestige, 0),
-        0,
+        0
       );
 
       return drawCards(
         4,
         discardHand({
           ...player,
-          prestige: Math.max(0, prestigeEarned + state.prestige),
-        }),
+          prestige: Math.max(0, prestigeEarned + player.prestige)
+        })
       );
 
-    case 'MOVE_PARTY':
+    case "MOVE_PARTY":
       const clamp = num => Math.max(0, Math.min(party.length));
       const start = clamp(0 - action.num);
       const end = clamp(party.length - action.num);
@@ -195,25 +226,35 @@ const reducePlayer = (state, player, action) => {
       return {
         ...player,
         party: movedParty,
-        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], []),
+        partyPool: movedParty.reduce((acc, table) => [...acc, ...table], [])
       };
+    case "SET_PRESTIGE":
+      return Object.assign({}, player, { prestige: action.num });
+    case "SET_MANA":
+      return Object.assign({}, player, { mana: action.num });
+    case "SET_HAND":
+      return Object.assign({}, player, { hand: action.hand });
+    case "SET_MY_DECK":
+      return Object.assign({}, player, { myDeck: action.myDeck });
+    case "SHUFFLE":
+      const shuffleobj = {};
+      shuffleobj[action.deckname] = player[action.deckname].sort(
+        () => Math.random() - 0.5
+      );
+      return Object.assign({}, player, shuffleobj);
+    case "DISCARD_FROM_HAND":
+      return Object.assign(
+        {},
+        state,
+        moveCardToPlayer(state, action.id, action.playerId, "discard")
+      );
+
     default:
       return player;
   }
 };
 
-export const reduceForPlayer = (state, action) => ({
-  ...state,
-  players: {
-    [action.playerId]: reducePlayer(
-      state,
-      state.players[action.playerId],
-      action,
-    ),
-  },
-});
-
-export const gameState = routeForOtherPlayer((state = baseState, action) => {
+export const gameState = routeForPlayer((state = baseState, action) => {
   let card;
   let {
     hand,
@@ -225,12 +266,10 @@ export const gameState = routeForOtherPlayer((state = baseState, action) => {
     myDeck,
     aura,
     trash,
-    discard,
+    discard
   } = state;
   switch (action.type) {
-    case 'APPLY_MANA':
-      return reduceForPlayer(state, action);
-    case 'BUY_FOOD':
+    case "BUY_FOOD":
       card = state.foodDeck.find(c => c.id == action.id);
 
       const cost = card.cost;
@@ -240,14 +279,11 @@ export const gameState = routeForOtherPlayer((state = baseState, action) => {
       }
 
       foodDeck = state.foodDeck.filter(c => c.id != action.id);
-      return reduceForPlayer(
-        {
-          ...state,
-          foodDeck,
-        },
-        action,
-      );
-    case 'ADD_GUEST':
+      return {
+        ...state,
+        foodDeck
+      };
+    case "ADD_GUEST":
       const newCard = state.guestDeck.find(c => c && c.id == action.id);
       if (state.players[action.playerId].mana < newCard.cost) {
         return state;
@@ -258,60 +294,41 @@ export const gameState = routeForOtherPlayer((state = baseState, action) => {
       if (newCard) {
         guestDeck = state.guestDeck.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDeck,
+          guestDeck
         });
-      } else if (oldCard) {
-        newState = Object.assign({}, state, { party, guestDeck, partyPool });
       } else if (disCard) {
         guestDiscard = state.guestDiscard.filter(c => c.id != action.id);
         newState = Object.assign({}, state, {
-          guestDiscard,
+          guestDiscard
         });
-      } 
-      return reduceForPlayer(newState, action);
-    case 'END_TURN':
-      return reduceForPlayer(state, action);
-    case 'MOVE_PARTY':
-      const partyObj = {};
-      partyObj.party = [[], [], [], [], [], [], []];
-      partyObj.guestDiscard = state.guestDiscard.slice(0);
-      partyObj.partyPool = state.partyPool.slice(0);
-      for (let i = 0; i < 7; i++) {
-        const newSpot = i + action.num;
-        if (newSpot < 0) {
-          partyObj.guestDiscard = partyObj.guestDiscard.concat(state.party[i]);
-        }
       }
-      return reduceForPlayer(Object.assign({}, state, partyObj), action);
-    case 'DISCARD_FROM_HAND':
-      return Object.assign({}, state, moveCard(state, action.id, "discard"));
-    case 'DISCARD_GUEST':
-      return Object.assign({}, state, moveCard(state, action.id, "guestDiscard"));
-    case 'TRASH_CARD':
-      return Object.assign({}, state, moveCard(state, action.id, "trash"));
-    case 'SET_AURA':
-      return Object.assign({}, state, moveCard(state, action.id, "aura"));
-    case 'DRAW_CARD':
-      return drawCard(state);
-    case 'SHUFFLE':
-      const shuffleobj = {};
-      shuffleobj[action.deckname] = state[action.deckname].sort(
-        () => Math.random() - 0.5,
+      return newState;
+    case "MOVE_PARTY":
+      return {
+        ...state,
+        guestDiscard: state.guestDiscard.concat(
+          state.players[action.playerId].party[0]
+        )
+      };
+    case "DISCARD_GUEST":
+      return Object.assign(
+        {},
+        state,
+        moveCard(state, action.id, "guestDiscard")
       );
-      return Object.assign({}, state, shuffleobj);
-    case 'PLAY_CARD':
-      return Object.assign({}, state, moveCard(state, action.id, "discard"));
-    case 'SET_PRESTIGE':
-      return Object.assign({}, state, { prestige: action.num });
-    case 'SET_MANA':
-      return Object.assign({}, state, { mana: action.num });
-    case 'SET_HAND':
-      return Object.assign({}, state, { hand: action.hand });
-    case 'SET_MY_DECK':
-      return Object.assign({}, state, { myDeck: action.myDeck });
-    case 'SET_FOOD_DECK':
+    case "TRASH_CARD":
+      return Object.assign({}, state, moveCard(state, action.id, "trash"));
+    case "SET_AURA":
+      return Object.assign({}, state, moveCard(state, action.id, "aura"));
+    case "PLAY_CARD":
+      return Object.assign(
+        {},
+        state,
+        moveCardToPlayer(state, action.id, action.playerId, "discard")
+      );
+    case "SET_FOOD_DECK":
       return Object.assign({}, state, { foodDeck: action.foodDeck });
-    case 'SET_GUEST_DECK':
+    case "SET_GUEST_DECK":
       return Object.assign({}, state, { guestDeck: action.guestDeck });
     default:
       return state;

--- a/app/reducers/gameState.test.js
+++ b/app/reducers/gameState.test.js
@@ -1,12 +1,17 @@
 import * as rawActions from "../actions";
 import {
   gameState as reduce,
-  baseState,
+  baseState as basestState,
   blankPlayer,
   discardHand,
   drawCard,
   drawCards
 } from "./gameState";
+
+const baseState = {
+  ...basestState,
+  playerId: 1
+};
 
 const card = {
   id: 0,

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
-const express = require('express');
-const app = require('express')();
-const server = require('http').createServer(app);
-const io = require('socket.io')(server);
+const express = require("express");
+const app = require("express")();
+const server = require("http").createServer(app);
+const io = require("socket.io")(server);
 
-io.on('connection', socket => {
-  console.log('connected');
-  socket.on('action', action => socket.broadcast.emit('action', action));
+io.on("connection", socket => {
+  console.log("connected");
+  socket.on("action", action => socket.broadcast.emit("action", action));
 });
 
-app.use('/', express.static('build'));
-app.use('/static', express.static('build/static'));
-app.use('/build', express.static('build'));
+app.use("/", express.static("build"));
+app.use("/static", express.static("build/static"));
+app.use("/build", express.static("build"));
 
 const port = process.argv[2] || 3000;
 
 server.listen(port, () => {
-  console.log('listening on ' + port);
+  console.log("listening on " + port);
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "webpack",
     "dev": "webpack-dev-server",
+    "format": "prettier --write index.js app/**/*.js*",
     "start": "node index.js",
     "test": "jest"
   },


### PR DESCRIPTION
Whoo, was this one a doozy! I am perfectly happy to change any implicit or explicit design call in here. It didn't take as long as the list of changes might look; mostly a bunch of moving statements around.

**High Level** Ensure that the app understands that some things affect specific players and others don't. Make sure the app doesn't _completely_ lose its mind while two people are connected.

* Add `playerId` and `players` keys to state.
* New assumption: actions dispatched with a falsey `playerId` are implicitly "mine".
* Add a `PICK_PLAYER` action.
* Add a _very_ crude component at load that prompts you to pick player 1 or 2. This doesn't even qualify for the word "lobby" yet :)
* Make some of the `didMount` side effects idempotent
* Refactor `gameState` reducer. Create a separate wrapper that reduces particular player states, as opposed to the central state. This is a _little_ weird in that, for example, it has both reducers checking whether a player can afford a card. They may be _too_ decoupled, sorry :)
* Update tests
* Update component-side references to `gameState` to target specific players.
* Add a `prettier` formatter command for fun

Aside: I tend to write extremely expression-oriented/functional code; I reach for `map`, `filter`, `reduce` etc as a first instinct. Is this ok? I don't want to ruin your flow if you find flow like this hard to parse! It helps me break down an answer into sub-answers, like solving a math problem.